### PR TITLE
More PostgreSQL datatypes support

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -29,6 +29,7 @@ jobs:
           sudo runuser -l postgres -c 'echo -e "geodiffpass\ngeodiffpass" | createuser -P -e geodiffuser'
           sudo runuser -l postgres -c 'psql -c "CREATE DATABASE geodiffdb"'
           sudo runuser -l postgres -c 'psql -d "geodiffdb" -c "CREATE EXTENSION postgis;"'
+          sudo runuser -l postgres -c 'psql -d "geodiffdb" -c "CREATE EXTENSION \"uuid-ossp\";"'
           sudo runuser -l postgres -c 'psql -c "GRANT ALL PRIVILEGES ON DATABASE geodiffdb TO geodiffuser"'
 
       - name: build geodiff with coverage

--- a/.github/workflows/memcheck_tests.yml
+++ b/.github/workflows/memcheck_tests.yml
@@ -27,6 +27,7 @@ jobs:
           sudo runuser -l postgres -c 'echo -e "geodiffpass\ngeodiffpass" | createuser -P -e geodiffuser'
           sudo runuser -l postgres -c 'psql -c "CREATE DATABASE geodiffdb"'
           sudo runuser -l postgres -c 'psql -d "geodiffdb" -c "CREATE EXTENSION postgis;"'
+          sudo runuser -l postgres -c 'psql -d "geodiffdb" -c "CREATE EXTENSION \"uuid-ossp\";"'
           sudo runuser -l postgres -c 'psql -c "GRANT ALL PRIVILEGES ON DATABASE geodiffdb TO geodiffuser"'
 
 

--- a/geodiff/src/drivers/postgresdriver.cpp
+++ b/geodiff/src/drivers/postgresdriver.cpp
@@ -479,7 +479,8 @@ static bool isColumnText( const TableColumnInfo &col )
   return col.type == "text" || startsWith( col.type.dbType, "text(" ) ||
          col.type == "varchar" || startsWith( col.type.dbType, "varchar(" ) ||
          col.type == "character varying" || startsWith( col.type.dbType, "character varying(" ) ||
-         col.type == "char" || col.type == "citext";
+         col.type == "char" || startsWith( col.type.dbType, "char(" ) || startsWith( col.type.dbType, "character(" ) ||
+         col.type == "citext";
 }
 
 static bool isColumnGeometry( const TableColumnInfo &col )

--- a/geodiff/src/drivers/postgresdriver.cpp
+++ b/geodiff/src/drivers/postgresdriver.cpp
@@ -480,7 +480,7 @@ static bool isColumnText( const TableColumnInfo &col )
          col.type == "varchar" || startsWith( col.type.dbType, "varchar(" ) ||
          col.type == "character varying" || startsWith( col.type.dbType, "character varying(" ) ||
          col.type == "char" || startsWith( col.type.dbType, "char(" ) || startsWith( col.type.dbType, "character(" ) ||
-         col.type == "citext";
+         col.type == "citext" || col.type == "uuid";
 }
 
 static bool isColumnGeometry( const TableColumnInfo &col )

--- a/geodiff/src/drivers/postgresdriver.cpp
+++ b/geodiff/src/drivers/postgresdriver.cpp
@@ -471,7 +471,7 @@ static bool isColumnInt( const TableColumnInfo &col )
 
 static bool isColumnDouble( const TableColumnInfo &col )
 {
-  return col.type == "real" || col.type == "double precision";
+  return col.type == "real" || col.type == "double precision" || startsWith( col.type.dbType, "numeric" );
 }
 
 static bool isColumnText( const TableColumnInfo &col )

--- a/geodiff/src/drivers/postgresdriver.cpp
+++ b/geodiff/src/drivers/postgresdriver.cpp
@@ -471,7 +471,8 @@ static bool isColumnInt( const TableColumnInfo &col )
 
 static bool isColumnDouble( const TableColumnInfo &col )
 {
-  return col.type == "real" || col.type == "double precision" || startsWith( col.type.dbType, "numeric" );
+  return col.type == "real" || col.type == "double precision" ||
+         startsWith( col.type.dbType, "numeric" ) || startsWith( col.type.dbType, "decimal" );
 }
 
 static bool isColumnText( const TableColumnInfo &col )
@@ -480,7 +481,7 @@ static bool isColumnText( const TableColumnInfo &col )
          col.type == "varchar" || startsWith( col.type.dbType, "varchar(" ) ||
          col.type == "character varying" || startsWith( col.type.dbType, "character varying(" ) ||
          col.type == "char" || startsWith( col.type.dbType, "char(" ) || startsWith( col.type.dbType, "character(" ) ||
-         col.type == "citext" || col.type == "uuid";
+         col.type == "citext";
 }
 
 static bool isColumnGeometry( const TableColumnInfo &col )
@@ -510,7 +511,7 @@ static Value resultToValue( const PostgresResult &res, int r, size_t i, const Ta
     {
       v.setDouble( atof( valueStr.c_str() ) );
     }
-    else if ( isColumnText( col ) )
+    else if ( isColumnText( col ) || col.type == "uuid" )
     {
       v.setString( Value::TypeText, valueStr.c_str(), valueStr.size() );
     }

--- a/geodiff/src/drivers/sqlitedriver.cpp
+++ b/geodiff/src/drivers/sqlitedriver.cpp
@@ -12,6 +12,7 @@
 #include "geodifflogger.hpp"
 
 #include <memory.h>
+#include <iostream>
 
 
 void SqliteDriver::logApplyConflict( const std::string &type, const ChangesetEntry &entry ) const
@@ -222,7 +223,7 @@ std::vector<std::string> SqliteDriver::listTables( bool useModified )
 
     tableNames.push_back( tableName );
   }
-  if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
+  if ( rc != SQLITE_DONE )
   {
     logSqliteError( context(), mDb, "Failed to list SQLite tables" );
   }
@@ -268,7 +269,7 @@ TableSchema SqliteDriver::tableSchema( const std::string &tableName,
 
     tbl.columns.push_back( columnInfo );
   }
-  if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
+  if ( rc != SQLITE_DONE )
   {
     logSqliteError( context(), mDb, "Failed to get list columns for table " + tableName );
   }
@@ -283,7 +284,7 @@ TableSchema SqliteDriver::tableSchema( const std::string &tableName,
     int srsId = -1;
     Sqlite3Stmt stmtGeomCol;
     stmtGeomCol.prepare( mDb, "SELECT * FROM \"%w\".gpkg_geometry_columns WHERE table_name = '%q'", dbName.c_str(), tableName.c_str() );
-    if ( SQLITE_ROW == ( rc = sqlite3_step( stmtGeomCol.get() ) ) )
+    while ( SQLITE_ROW == ( rc = sqlite3_step( stmtGeomCol.get() ) ) )
     {
       const unsigned char *chrColumnName = sqlite3_column_text( stmtGeomCol.get(), 1 );
       const unsigned char *chrTypeName = sqlite3_column_text( stmtGeomCol.get(), 2 );
@@ -305,7 +306,7 @@ TableSchema SqliteDriver::tableSchema( const std::string &tableName,
       TableColumnInfo &col = tbl.columns[i];
       col.setGeometry( geomTypeName, srsId, hasM, hasZ );
     }
-    if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
+    if ( rc != SQLITE_DONE )
     {
       logSqliteError( context(), mDb, "Failed to get geometry column info for table " + tableName );
     }
@@ -484,7 +485,7 @@ static void handleInserted( const Context *context, const std::string &tableName
 
     writer.writeEntry( e );
   }
-  if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
+  if ( rc != SQLITE_DONE )
   {
     logSqliteError( context, db, "Failed to write information about inserted rows in table " + tableName );
   }
@@ -564,7 +565,7 @@ static void handleUpdated( const Context *context, const std::string &tableName,
       writer.writeEntry( e );
     }
   }
-  if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
+  if ( rc != SQLITE_DONE )
   {
     logSqliteError( context, db, "Failed to write information about inserted rows in table " + tableName );
   }
@@ -1063,7 +1064,7 @@ void SqliteDriver::dumpData( ChangesetWriter &writer, bool useModified )
       }
       writer.writeEntry( e );
     }
-    if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
+    if ( rc != SQLITE_DONE )
     {
       logSqliteError( context(), mDb, "Failure dumping changeset" );
     }

--- a/geodiff/src/drivers/sqlitedriver.cpp
+++ b/geodiff/src/drivers/sqlitedriver.cpp
@@ -222,7 +222,7 @@ std::vector<std::string> SqliteDriver::listTables( bool useModified )
 
     tableNames.push_back( tableName );
   }
-  if ( rc != SQLITE_DONE )
+  if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
   {
     logSqliteError( context(), mDb, "Failed to list SQLite tables" );
   }
@@ -268,7 +268,7 @@ TableSchema SqliteDriver::tableSchema( const std::string &tableName,
 
     tbl.columns.push_back( columnInfo );
   }
-  if ( rc != SQLITE_DONE )
+  if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
   {
     logSqliteError( context(), mDb, "Failed to get list columns for table " + tableName );
   }
@@ -305,7 +305,7 @@ TableSchema SqliteDriver::tableSchema( const std::string &tableName,
       TableColumnInfo &col = tbl.columns[i];
       col.setGeometry( geomTypeName, srsId, hasM, hasZ );
     }
-    if ( rc != SQLITE_DONE )
+    if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
     {
       logSqliteError( context(), mDb, "Failed to get geometry column info for table " + tableName );
     }
@@ -484,7 +484,7 @@ static void handleInserted( const Context *context, const std::string &tableName
 
     writer.writeEntry( e );
   }
-  if ( rc != SQLITE_DONE )
+  if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
   {
     logSqliteError( context, db, "Failed to write information about inserted rows in table " + tableName );
   }
@@ -564,7 +564,7 @@ static void handleUpdated( const Context *context, const std::string &tableName,
       writer.writeEntry( e );
     }
   }
-  if ( rc != SQLITE_DONE )
+  if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
   {
     logSqliteError( context, db, "Failed to write information about inserted rows in table " + tableName );
   }
@@ -1063,7 +1063,7 @@ void SqliteDriver::dumpData( ChangesetWriter &writer, bool useModified )
       }
       writer.writeEntry( e );
     }
-    if ( rc != SQLITE_DONE )
+    if ( rc != SQLITE_DONE && rc != SQLITE_ROW )
     {
       logSqliteError( context(), mDb, "Failure dumping changeset" );
     }

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -770,17 +770,19 @@ int GEODIFF_makeCopy( GEODIFF_ContextH contextHandle,
     return GEODIFF_ERROR;
   }
 
-  std::unique_ptr<Driver> driverSrc( Driver::createDriver( context, std::string( driverSrcName ) ) );
+  std::string srcDriverName( driverSrcName );
+  std::string dstDriverName( driverDstName );
+  std::unique_ptr<Driver> driverSrc( Driver::createDriver( context, srcDriverName ) );
   if ( !driverSrc )
   {
-    context->logger().error( "Cannot create driver " + std::string( driverSrcName ) );
+    context->logger().error( "Cannot create driver " + srcDriverName );
     return GEODIFF_ERROR;
   }
 
-  std::unique_ptr<Driver> driverDst( Driver::createDriver( context, std::string( driverDstName ) ) );
+  std::unique_ptr<Driver> driverDst( Driver::createDriver( context, dstDriverName ) );
   if ( !driverDst )
   {
-    context->logger().error( "Cannot create driver " + std::string( driverDstName ) );
+    context->logger().error( "Cannot create driver " + dstDriverName );
     return GEODIFF_ERROR;
   }
 
@@ -797,10 +799,16 @@ int GEODIFF_makeCopy( GEODIFF_ContextH contextHandle,
     // get source tables
     std::vector<TableSchema> tables;
     std::vector<std::string> tableNames = driverSrc->listTables();
+
     for ( const std::string &tableName : tableNames )
     {
       TableSchema tbl = driverSrc->tableSchema( tableName );
-      tableSchemaConvert( driverDstName, tbl );
+      // convert table schemas only if source and descrination drivers are
+      // different, otherwise copied table will have different column types
+      if ( srcDriverName != dstDriverName )
+      {
+        tableSchemaConvert( driverDstName, tbl );
+      }
       tables.push_back( tbl );
     }
 

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -800,16 +800,22 @@ int GEODIFF_makeCopy( GEODIFF_ContextH contextHandle,
     std::vector<TableSchema> tables;
     std::vector<std::string> tableNames = driverSrc->listTables();
 
-    for ( const std::string &tableName : tableNames )
+    if ( srcDriverName != dstDriverName )
     {
-      TableSchema tbl = driverSrc->tableSchema( tableName );
-      // convert table schemas only if source and descrination drivers are
-      // different, otherwise copied table will have different column types
-      if ( srcDriverName != dstDriverName )
+      for ( const std::string &tableName : tableNames )
       {
+        TableSchema tbl = driverSrc->tableSchema( tableName );
         tableSchemaConvert( driverDstName, tbl );
+        tables.push_back( tbl );
       }
-      tables.push_back( tbl );
+    }
+    else
+    {
+      for ( const std::string &tableName : tableNames )
+      {
+        TableSchema tbl = driverSrc->tableSchema( tableName );
+        tables.push_back( tbl );
+      }
     }
 
     // get source data

--- a/geodiff/src/tableschema.cpp
+++ b/geodiff/src/tableschema.cpp
@@ -110,7 +110,7 @@ TableColumnType postgresToBaseColumn(
   {
     type.baseType = TableColumnType::INTEGER;
   }
-  else if ( dbType == "double precision" || dbType == "real" )
+  else if ( dbType == "double precision" || dbType == "real" || startsWith( dbType, "numeric" ) )
   {
     type.baseType = TableColumnType::DOUBLE;
   }

--- a/geodiff/src/tableschema.cpp
+++ b/geodiff/src/tableschema.cpp
@@ -122,7 +122,7 @@ TableColumnType postgresToBaseColumn(
             dbType == "varchar" || startsWith( dbType, "varchar(" ) ||
             dbType == "character varying" || startsWith( dbType, "character varying(" ) ||
             dbType == "char" || startsWith( dbType, "char(" ) || startsWith( dbType, "character(" ) ||
-            dbType == "citetext" )
+            dbType == "citetext" || dbType == "uuid" )
   {
     type.baseType = TableColumnType::TEXT;
   }

--- a/geodiff/src/tableschema.cpp
+++ b/geodiff/src/tableschema.cpp
@@ -110,7 +110,8 @@ TableColumnType postgresToBaseColumn(
   {
     type.baseType = TableColumnType::INTEGER;
   }
-  else if ( dbType == "double precision" || dbType == "real" || startsWith( dbType, "numeric" ) )
+  else if ( dbType == "double precision" || dbType == "real" || startsWith( dbType, "numeric" ) ||
+            startsWith( dbType, "decimal" ) )
   {
     type.baseType = TableColumnType::DOUBLE;
   }

--- a/geodiff/src/tableschema.cpp
+++ b/geodiff/src/tableschema.cpp
@@ -121,7 +121,8 @@ TableColumnType postgresToBaseColumn(
   else if ( dbType == "text" || startsWith( dbType, "text(" ) ||
             dbType == "varchar" || startsWith( dbType, "varchar(" ) ||
             dbType == "character varying" || startsWith( dbType, "character varying(" ) ||
-            dbType == "char" || dbType == "citetext" )
+            dbType == "char" || startsWith( dbType, "char(" ) || startsWith( dbType, "character(" ) ||
+            dbType == "citetext" )
   {
     type.baseType = TableColumnType::TEXT;
   }

--- a/geodiff/tests/test_driver_postgres.cpp
+++ b/geodiff/tests/test_driver_postgres.cpp
@@ -134,7 +134,7 @@ TEST( PostgresDriverTest, test_datatypes )
 
   TableSchema sch = driver->tableSchema( "simple" );
   ASSERT_EQ( sch.name, "simple" );
-  ASSERT_EQ( sch.columns.size(), 7 );
+  ASSERT_EQ( sch.columns.size(), 8 );
 
   ASSERT_EQ( sch.columns[0].name, "fid" );
   ASSERT_EQ( sch.columns[0].type.baseType, TableColumnType::INTEGER );
@@ -195,6 +195,14 @@ TEST( PostgresDriverTest, test_datatypes )
   ASSERT_EQ( sch.columns[6].isNotNull, false );
   ASSERT_EQ( sch.columns[6].isAutoIncrement, false );
   ASSERT_EQ( sch.columns[6].isGeometry, false );
+
+  ASSERT_EQ( sch.columns[7].name, "col_numeric" );
+  ASSERT_EQ( sch.columns[7].type.baseType, TableColumnType::DOUBLE );
+  ASSERT_EQ( sch.columns[7].type.dbType, "numeric(10,3)" );
+  ASSERT_EQ( sch.columns[7].isPrimaryKey, false );
+  ASSERT_EQ( sch.columns[7].isNotNull, false );
+  ASSERT_EQ( sch.columns[7].isAutoIncrement, false );
+  ASSERT_EQ( sch.columns[7].isGeometry, false );
 }
 
 void testCreateChangeset( const std::string &testname, const std::string &conninfo, const std::string &schemaBase, const std::string &schemaModified, const std::string &expectedChangeset )

--- a/geodiff/tests/test_driver_postgres.cpp
+++ b/geodiff/tests/test_driver_postgres.cpp
@@ -203,6 +203,14 @@ TEST( PostgresDriverTest, test_datatypes )
   ASSERT_EQ( sch.columns[7].isNotNull, false );
   ASSERT_EQ( sch.columns[7].isAutoIncrement, false );
   ASSERT_EQ( sch.columns[7].isGeometry, false );
+
+  ASSERT_EQ( sch.columns[7].name, "col_decimal" );
+  ASSERT_EQ( sch.columns[7].type.baseType, TableColumnType::DOUBLE );
+  ASSERT_EQ( sch.columns[7].type.dbType, "decimal(10,3)" );
+  ASSERT_EQ( sch.columns[7].isPrimaryKey, false );
+  ASSERT_EQ( sch.columns[7].isNotNull, false );
+  ASSERT_EQ( sch.columns[7].isAutoIncrement, false );
+  ASSERT_EQ( sch.columns[7].isGeometry, false );
 }
 
 TEST( PostgresDriverTest, test_makeCopy )

--- a/geodiff/tests/test_driver_postgres.cpp
+++ b/geodiff/tests/test_driver_postgres.cpp
@@ -134,9 +134,10 @@ TEST( PostgresDriverTest, test_datatypes )
 
   TableSchema sch = driver->tableSchema( "simple" );
   ASSERT_EQ( sch.name, "simple" );
-  ASSERT_EQ( sch.columns.size(), 6 );
+  ASSERT_EQ( sch.columns.size(), 7 );
 
   ASSERT_EQ( sch.columns[0].name, "fid" );
+  ASSERT_EQ( sch.columns[0].type.baseType, TableColumnType::INTEGER );
   ASSERT_EQ( sch.columns[0].type.dbType, "integer" );
   ASSERT_EQ( sch.columns[0].isPrimaryKey, true );
   ASSERT_EQ( sch.columns[0].isNotNull, true );
@@ -144,6 +145,7 @@ TEST( PostgresDriverTest, test_datatypes )
   ASSERT_EQ( sch.columns[0].isGeometry, false );
 
   ASSERT_EQ( sch.columns[1].name, "geometry" );
+  ASSERT_EQ( sch.columns[1].type.baseType, TableColumnType::GEOMETRY );
   ASSERT_EQ( sch.columns[1].type.dbType, "geometry(Point,4326)" );
   ASSERT_EQ( sch.columns[1].isPrimaryKey, false );
   ASSERT_EQ( sch.columns[1].isNotNull, false );
@@ -155,6 +157,7 @@ TEST( PostgresDriverTest, test_datatypes )
   ASSERT_EQ( sch.columns[1].geomHasM, false );
 
   ASSERT_EQ( sch.columns[2].name, "name_text" );
+  ASSERT_EQ( sch.columns[2].type.baseType, TableColumnType::TEXT );
   ASSERT_EQ( sch.columns[2].type.dbType, "text" );
   ASSERT_EQ( sch.columns[2].isPrimaryKey, false );
   ASSERT_EQ( sch.columns[2].isNotNull, false );
@@ -162,6 +165,7 @@ TEST( PostgresDriverTest, test_datatypes )
   ASSERT_EQ( sch.columns[2].isGeometry, false );
 
   ASSERT_EQ( sch.columns[3].name, "name_varchar" );
+  ASSERT_EQ( sch.columns[3].type, TableColumnType::TEXT );
   ASSERT_EQ( sch.columns[3].type.dbType, "character varying" );
   ASSERT_EQ( sch.columns[3].isPrimaryKey, false );
   ASSERT_EQ( sch.columns[3].isNotNull, false );
@@ -169,6 +173,7 @@ TEST( PostgresDriverTest, test_datatypes )
   ASSERT_EQ( sch.columns[3].isGeometry, false );
 
   ASSERT_EQ( sch.columns[4].name, "name_varchar_len" );
+  ASSERT_EQ( sch.columns[4].type.baseType, TableColumnType::TEXT );
   ASSERT_EQ( sch.columns[4].type.dbType, "character varying(50)" );
   ASSERT_EQ( sch.columns[4].isPrimaryKey, false );
   ASSERT_EQ( sch.columns[4].isNotNull, false );
@@ -176,11 +181,20 @@ TEST( PostgresDriverTest, test_datatypes )
   ASSERT_EQ( sch.columns[4].isGeometry, false );
 
   ASSERT_EQ( sch.columns[5].name, "name_char_len" );
+  ASSERT_EQ( sch.columns[5].type.baseType, TableColumnType::TEXT );
   ASSERT_EQ( sch.columns[5].type.dbType, "character(100)" );
   ASSERT_EQ( sch.columns[5].isPrimaryKey, false );
   ASSERT_EQ( sch.columns[5].isNotNull, false );
   ASSERT_EQ( sch.columns[5].isAutoIncrement, false );
   ASSERT_EQ( sch.columns[5].isGeometry, false );
+
+  ASSERT_EQ( sch.columns[6].name, "feature_id" );
+  ASSERT_EQ( sch.columns[6].type.baseType, TableColumnType::TEXT );
+  ASSERT_EQ( sch.columns[6].type.dbType, "uuid" );
+  ASSERT_EQ( sch.columns[6].isPrimaryKey, false );
+  ASSERT_EQ( sch.columns[6].isNotNull, false );
+  ASSERT_EQ( sch.columns[6].isAutoIncrement, false );
+  ASSERT_EQ( sch.columns[6].isGeometry, false );
 }
 
 void testCreateChangeset( const std::string &testname, const std::string &conninfo, const std::string &schemaBase, const std::string &schemaModified, const std::string &expectedChangeset )

--- a/geodiff/tests/test_driver_postgres.cpp
+++ b/geodiff/tests/test_driver_postgres.cpp
@@ -134,7 +134,7 @@ TEST( PostgresDriverTest, test_datatypes )
 
   TableSchema sch = driver->tableSchema( "simple" );
   ASSERT_EQ( sch.name, "simple" );
-  ASSERT_EQ( sch.columns.size(), 8 );
+  ASSERT_EQ( sch.columns.size(), 9 );
 
   ASSERT_EQ( sch.columns[0].name, "fid" );
   ASSERT_EQ( sch.columns[0].type.baseType, TableColumnType::INTEGER );
@@ -204,13 +204,13 @@ TEST( PostgresDriverTest, test_datatypes )
   ASSERT_EQ( sch.columns[7].isAutoIncrement, false );
   ASSERT_EQ( sch.columns[7].isGeometry, false );
 
-  ASSERT_EQ( sch.columns[7].name, "col_decimal" );
-  ASSERT_EQ( sch.columns[7].type.baseType, TableColumnType::DOUBLE );
-  ASSERT_EQ( sch.columns[7].type.dbType, "decimal(10,3)" );
-  ASSERT_EQ( sch.columns[7].isPrimaryKey, false );
-  ASSERT_EQ( sch.columns[7].isNotNull, false );
-  ASSERT_EQ( sch.columns[7].isAutoIncrement, false );
-  ASSERT_EQ( sch.columns[7].isGeometry, false );
+  ASSERT_EQ( sch.columns[8].name, "col_decimal" );
+  ASSERT_EQ( sch.columns[8].type.baseType, TableColumnType::DOUBLE );
+  ASSERT_EQ( sch.columns[8].type.dbType, "numeric(10,3)" );
+  ASSERT_EQ( sch.columns[8].isPrimaryKey, false );
+  ASSERT_EQ( sch.columns[8].isNotNull, false );
+  ASSERT_EQ( sch.columns[8].isAutoIncrement, false );
+  ASSERT_EQ( sch.columns[8].isGeometry, false );
 }
 
 TEST( PostgresDriverTest, test_makeCopy )

--- a/geodiff/tests/testdata/postgres/datatypes.sql
+++ b/geodiff/tests/testdata/postgres/datatypes.sql
@@ -2,6 +2,7 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 DROP SCHEMA IF EXISTS gd_datatypes CASCADE;
+DROP SCHEMA IF EXISTS gd_datatypes_copy CASCADE;
 
 CREATE SCHEMA gd_datatypes;
 

--- a/geodiff/tests/testdata/postgres/datatypes.sql
+++ b/geodiff/tests/testdata/postgres/datatypes.sql
@@ -12,7 +12,8 @@ CREATE TABLE gd_datatypes.simple (
     "name_varchar_len" character varying(50),
     "name_char_len" character(100),
     "feature_id" uuid DEFAULT uuid_generate_v4(),
-    "col_numeric" numeric(10,3)
+    "col_numeric" numeric(10,3),
+    "col_decimal" decimal(10,3)
 );
 
 INSERT INTO gd_datatypes.simple (
@@ -22,7 +23,8 @@ INSERT INTO gd_datatypes.simple (
     "name_varchar",
     "name_varchar_len",
     "name_char_len",
-    "col_numeric"
+    "col_numeric",
+    "col_decimal"
 )
 VALUES (
     1,
@@ -31,5 +33,6 @@ VALUES (
     'feature1 varchar',
     'feature1 varchar(50)',
     'feature1 char(100)',
-    31.203
+    31.203,
+    13.302
 );

--- a/geodiff/tests/testdata/postgres/datatypes.sql
+++ b/geodiff/tests/testdata/postgres/datatypes.sql
@@ -1,0 +1,22 @@
+
+DROP SCHEMA IF EXISTS gd_datatypes CASCADE;
+
+CREATE SCHEMA gd_datatypes;
+
+CREATE TABLE gd_datatypes.simple (
+    "fid" SERIAL PRIMARY KEY,
+    "geometry" GEOMETRY(POINT, 4326),
+    "name_text" text,
+    "name_varchar" character varying,
+    "name_varchar_len" character varying(50),
+    "name_char_len" character(100)
+);
+
+INSERT INTO gd_datatypes.simple VALUES (
+    1,
+    ST_GeomFromText('Point (-1.08891928864569065 0.46101231190150482)', 4326),
+    'feature1',
+    'feature1 varchar',
+    'feature1 varchar(50)',
+    'feature1 char(100)'
+);

--- a/geodiff/tests/testdata/postgres/datatypes.sql
+++ b/geodiff/tests/testdata/postgres/datatypes.sql
@@ -12,7 +12,8 @@ CREATE TABLE gd_datatypes.simple (
     "name_varchar" character varying,
     "name_varchar_len" character varying(50),
     "name_char_len" character(100),
-    "feature_id" uuid DEFAULT uuid_generate_v4()
+    "feature_id" uuid DEFAULT uuid_generate_v4(),
+    "col_numeric" numeric(10,3)
 );
 
 INSERT INTO gd_datatypes.simple (
@@ -21,7 +22,8 @@ INSERT INTO gd_datatypes.simple (
     "name_text",
     "name_varchar",
     "name_varchar_len",
-    "name_char_len"
+    "name_char_len",
+    "col_numeric"
 )
 VALUES (
     1,
@@ -29,5 +31,6 @@ VALUES (
     'feature1',
     'feature1 varchar',
     'feature1 varchar(50)',
-    'feature1 char(100)'
+    'feature1 char(100)',
+    31.203
 );

--- a/geodiff/tests/testdata/postgres/datatypes.sql
+++ b/geodiff/tests/testdata/postgres/datatypes.sql
@@ -1,4 +1,6 @@
 
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 DROP SCHEMA IF EXISTS gd_datatypes CASCADE;
 
 CREATE SCHEMA gd_datatypes;
@@ -9,10 +11,19 @@ CREATE TABLE gd_datatypes.simple (
     "name_text" text,
     "name_varchar" character varying,
     "name_varchar_len" character varying(50),
-    "name_char_len" character(100)
+    "name_char_len" character(100),
+    "feature_id" uuid DEFAULT uuid_generate_v4()
 );
 
-INSERT INTO gd_datatypes.simple VALUES (
+INSERT INTO gd_datatypes.simple (
+    "fid",
+    "geometry",
+    "name_text",
+    "name_varchar",
+    "name_varchar_len",
+    "name_char_len"
+)
+VALUES (
     1,
     ST_GeomFromText('Point (-1.08891928864569065 0.46101231190150482)', 4326),
     'feature1',

--- a/geodiff/tests/testdata/postgres/datatypes.sql
+++ b/geodiff/tests/testdata/postgres/datatypes.sql
@@ -1,6 +1,4 @@
 
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-
 DROP SCHEMA IF EXISTS gd_datatypes CASCADE;
 DROP SCHEMA IF EXISTS gd_datatypes_copy CASCADE;
 


### PR DESCRIPTION
Adds support for more PostgreSQL datatypes:

- `character(N)` and `char(N)` (fixes #177)
- `numeric(M, N)`
- `uuid` (fixes #157)

Avoid datatypes conversion while making copy of the database if source and destitation drivers are the same. This allows to use native datatypes and avoid conversion issues (fixes #176).