### PR TITLE
Fix python CI crash in mergin-py-client

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -15,9 +15,7 @@ jobs:
           sudo apt-get install -y lcov
           sudo apt-get install libpq-dev
           sudo apt-get install postgresql-12 postgresql-contrib-12 postgresql-12-postgis-3 postgresql-common postgis
-          sudo apt-get install -y python3 libsqlite3-dev cmake cmake-data
-          sudo python3 scripts/ci/get-pip.py
-          sudo python3 -m pip install nose2
+          sudo apt-get install -y python3 python3-pytest libsqlite3-dev cmake cmake-data
 
       - name: start PG database
         run: |
@@ -54,7 +52,7 @@ jobs:
 
       - name: Run python tests
         run: |
-          GEODIFFLIB=`pwd`/build_coverage_lnx/libgeodiff.so nose2
+          GEODIFFLIB=`pwd`/build_coverage_lnx/libgeodiff.so pytest-3
 
       - name: Prepare coverage report
         run: |

--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run python tests
         run: |
-          GEODIFFLIB=`pwd`/build_coverage_lnx/libgeodiff.so pytest-3
+          GEODIFFLIB=`pwd`/build_coverage_lnx/libgeodiff.so pytest-3 pygeodiff/
 
       - name: Prepare coverage report
         run: |

--- a/.github/workflows/python_packages.yml
+++ b/.github/workflows/python_packages.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install Deps
         run: |
           brew install sqlite3
-          pip install setuptools scikit-build wheel cmake nose2
+          pip install setuptools scikit-build wheel cmake
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ C++ tests: run `make test` or `ctest` to run all tests. Alternatively run just a
 
 Python tests: you need to setup GEODIFFLIB with path to .so/.dylib from build step
 ```bash
-GEODIFFLIB=`pwd`/../build/libgeodiff.dylib nose2
+GEODIFFLIB=`pwd`/../build/libgeodiff.dylib pytest
 ```
 
 ### Releasing new version

--- a/pygeodiff/geodifflib.py
+++ b/pygeodiff/geodifflib.py
@@ -82,7 +82,7 @@ class GeoDiffLib:
 
         # ChangesetReader
         self._CR_nextEntry = self.lib.GEODIFF_CR_nextEntry
-        self._CR_nextEntry.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        self._CR_nextEntry.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
         self._CR_nextEntry.restype = ctypes.c_void_p
 
         self._CR_destroy = self.lib.GEODIFF_CR_destroy
@@ -102,11 +102,11 @@ class GeoDiffLib:
         self._CE_count.restype = ctypes.c_int
 
         self._CE_old_value = self.lib.GEODIFF_CE_oldValue
-        self._CE_old_value.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self._CE_old_value.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
         self._CE_old_value.restype = ctypes.c_void_p
 
         self._CE_new_value = self.lib.GEODIFF_CE_newValue
-        self._CE_new_value.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self._CE_new_value.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
         self._CE_new_value.restype = ctypes.c_void_p
 
         self._CE_destroy = self.lib.GEODIFF_CE_destroy
@@ -122,7 +122,7 @@ class GeoDiffLib:
         self._CT_column_count.restype = ctypes.c_int
 
         self._CT_column_is_pkey = self.lib.GEODIFF_CT_columnIsPkey
-        self._CT_column_is_pkey.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self._CT_column_is_pkey.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
         self._CT_column_is_pkey.restype = ctypes.c_bool
 
         # Value

--- a/pygeodiff/tests/test_changeset_reader.py
+++ b/pygeodiff/tests/test_changeset_reader.py
@@ -56,9 +56,9 @@ class UnitTestsChangesetReader(GeoDiffTests):
         changeset = os.path.join(testdir(), "2_inserts", "base-inserted_1_A.diff")
         i = 0
         for entry in self.geodiff.read_changeset(changeset):
-            self.assertEquals(entry.table.name, 'simple')
-            self.assertEquals(entry.new_values[0], 4)
-            self.assertEquals(entry.new_values[2], 'my new point A')
+            self.assertEqual(entry.table.name, 'simple')
+            self.assertEqual(entry.new_values[0], 4)
+            self.assertEqual(entry.new_values[2], 'my new point A')
             with self.assertRaises(AttributeError):
                 print(entry.old_values)   # with INSERT the "old_values" attribute is not set
             i += 1
@@ -68,9 +68,9 @@ class UnitTestsChangesetReader(GeoDiffTests):
         changeset = os.path.join(testdir(), "2_deletes", "base-deleted_A.diff")
         i = 0
         for entry in self.geodiff.read_changeset(changeset):
-            self.assertEquals(entry.table.name, 'simple')
-            self.assertEquals(entry.old_values[0], 2)
-            self.assertEquals(entry.old_values[2], 'feature2')
+            self.assertEqual(entry.table.name, 'simple')
+            self.assertEqual(entry.old_values[0], 2)
+            self.assertEqual(entry.old_values[2], 'feature2')
             with self.assertRaises(AttributeError):
                 print(entry.new_values)   # with DELETE the "new_values" attribute is not set
             i += 1

--- a/pygeodiff/tests/test_changeset_reader.py
+++ b/pygeodiff/tests/test_changeset_reader.py
@@ -44,6 +44,8 @@ class UnitTestsChangesetReader(GeoDiffTests):
                 self.assertEqual(entry.old_values[0], 'simple')
             else:  # change in 'simple' table
                 self.assertEqual(entry.table.name, 'simple')
+                self.assertEqual(entry.table.column_is_pkey[0], True)
+                self.assertEqual(entry.table.column_is_pkey[1], False)
                 self.assertEqual(entry.old_values[0], 1)
                 self.assertIsInstance(entry.new_values[0], UndefinedValue)
                 self.assertIsInstance(entry.old_values[1], bytes)

--- a/pygeodiff/tests/testutils.py
+++ b/pygeodiff/tests/testutils.py
@@ -12,7 +12,7 @@ import json
 import shutil
 
 class TestError(Exception):
-  pass
+    __test__ = False   # this is not a test class, this will make pytest to ignore it
 
 
 REFDIF = os.path.dirname(os.path.realpath(__file__))
@@ -76,6 +76,9 @@ def test_json(geodiff, changeset, json, expect_success ):
 
     print("check export to JSON ")
     _test_json(geodiff.list_changes, changeset, json, expect_success)
+
+
+test_json.__test__ = False  # this is not a standalone test, this will make pytest to ignore it
 
 
 def compare_json(json_file, expected_json):


### PR DESCRIPTION
In mergin-py-client we're getting segfaults in CI with the new geodiff release:
```
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/pygeodiff/geodifflib.py", line 542 in __init__
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/pygeodiff/geodifflib.py", line 501 in next_entry
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/pygeodiff/geodifflib.py", line 509 in __next__
  File "/home/runner/work/mergin-py-client/mergin-py-client/mergin/report.py", line 162 in changeset_report
  File "/home/runner/work/mergin-py-client/mergin-py-client/mergin/report.py", line 269 in create_report
  File "/home/runner/work/mergin-py-client/mergin-py-client/mergin/test/test_client.py", line 1684 in test_report
```
GDB further points to GEODIFF_CE_newValue() function.
```
0x00007ffff51382a0 in GEODIFF_CE_newValue ()
   from /opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/pygeodiff/libpygeodiff-2.0.0-python.so
#0  0x00007ffff51382a0 in GEODIFF_CE_newValue ()
   from /opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/pygeodiff/libpygeodiff-2.0.0-python.so
#1  0x00007ffff5bffff5 in ?? () from /lib/x86_64-linux-gnu/libffi.so.7
#2  0x00007ffff5bff40a in ?? () from /lib/x86_64-linux-gnu/libffi.so.7
```

It looks like in geodifflib.py, few C functions didn't get arguments updated when contexts were added in #172 - with `GEODIFF_CE_newValue` being one of them. On my local machine there's no segfault, so I can't properly verify the fix (but there's nothing else looking suspicious there).

Also:
- switched from nose2 to pytest for python tests so that we use the same tool everywhere and fixed few places where pytest complained about things
- added tests for `column_is_pkey` in changeset reader test
