### PR TITLE
Add tests for geodiff-cli

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Run python tests
         run: |
-          GEODIFFLIB=`pwd`/build_coverage_lnx/libgeodiff.so pytest-3 pygeodiff/
+          GEODIFFLIB=`pwd`/build_coverage_lnx/libgeodiff.so \
+          GEODIFFCLI=`pwd`/build_coverage_lnx/geodiff \
+          pytest-3 pygeodiff/
 
       - name: Prepare coverage report
         run: |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ C++ tests: run `make test` or `ctest` to run all tests. Alternatively run just a
 
 Python tests: you need to setup GEODIFFLIB with path to .so/.dylib from build step
 ```bash
-GEODIFFLIB=`pwd`/../build/libgeodiff.dylib pytest
+GEODIFFLIB=`pwd`/../build/libgeodiff.dylib GEODIFFCLI=`pwd`/build/geodiff pytest
 ```
 
 ### Releasing new version

--- a/geodiff/src/geodiff-cli.cpp
+++ b/geodiff/src/geodiff-cli.cpp
@@ -780,7 +780,9 @@ static int handleCmdDrivers( const std::vector<std::string> &args )
 
 static int handleCmdVersion( const std::vector<std::string> &args )
 {
-  ( void )args;
+  size_t i = 1;
+  if ( !checkNoExtraArguments( args, i, "version" ) )
+    return 1;
 
   std::cout << GEODIFF_version() << std::endl;
   return 0;
@@ -793,7 +795,10 @@ static GEODIFF_LoggerLevel getGeodiffLoggerLevel( )
 
 static int handleCmdHelp( const std::vector<std::string> &args )
 {
-  ( void )args; // arguments unused
+  size_t i = 1;
+  if ( !checkNoExtraArguments( args, i, "help" ) )
+    return 1;
+
 
   std::cout << "GEODIFF " << GEODIFF_version() << ", a tool for handling diffs for geospatial data.\n\
 \n\
@@ -970,7 +975,7 @@ Utilities:\n\
 \n\
     Prints this help information.\n\
 \n\
-Copyright (C) 2019-2021 Lutra Consulting\n\
+Copyright (C) 2019-2023 Lutra Consulting\n\
 ";
   return 0;
 }

--- a/pygeodiff/tests/test_api_calls.py
+++ b/pygeodiff/tests/test_api_calls.py
@@ -20,8 +20,7 @@ class UnitTestsPythonApiCalls(GeoDiffTests):
         print("********************************************************")
         print("PYTHON: test API calls")
 
-        outdir = tmpdir() + "/pyapi-calls"
-        create_dir("api-calls")
+        outdir = create_dir("api-calls")
 
         print("-- driver_api")
         if len(self.geodiff.drivers()) < 1:
@@ -32,81 +31,81 @@ class UnitTestsPythonApiCalls(GeoDiffTests):
            
         print("-- concat_changes")
         self.geodiff.concat_changes(
-            [testdir()+'/concat/foo-insert-update-1.diff', testdir()+'/concat/foo-insert-update-2.diff'],
+            [geodiff_test_dir()+'/concat/foo-insert-update-1.diff', geodiff_test_dir()+'/concat/foo-insert-update-2.diff'],
             outdir+'/concat.diff')
 
         self.geodiff.concat_changes(
-            [testdir()+'/concat/bar-insert.diff', testdir()+'/concat/bar-update.diff', testdir()+'/concat/bar-delete.diff'],
+            [geodiff_test_dir()+'/concat/bar-insert.diff', geodiff_test_dir()+'/concat/bar-update.diff', geodiff_test_dir()+'/concat/bar-delete.diff'],
             outdir+'/concat.diff')
 
         # This is not a valid concat - you delete feature and then update (deleted feature) and then insert it
         # But it should not crash. Ideally update is ignored (invalid step) and insert is applied
         # https://github.com/MerginMaps/geodiff/issues/174
         self.geodiff.concat_changes(
-            [testdir()+'/concat/bar-delete.diff', testdir()+'/concat/bar-update.diff', testdir()+'/concat/bar-insert.diff'],
+            [geodiff_test_dir()+'/concat/bar-delete.diff', geodiff_test_dir()+'/concat/bar-update.diff', geodiff_test_dir()+'/concat/bar-insert.diff'],
             outdir+'/concat.diff')
 
         print("-- make_copy")
         self.geodiff.make_copy(
             'sqlite', '',
-            testdir()+'/base.gpkg',
+            geodiff_test_dir()+'/base.gpkg',
             'sqlite', '',
             outdir+'/make-copy.gpkg')
 
         print("-- make_copy_sqlite")
         self.geodiff.make_copy_sqlite(
-            testdir()+'/base.gpkg',
+            geodiff_test_dir()+'/base.gpkg',
             outdir+'/make-copy-sqlite.gpkg')
 
         print("-- create_changeset_ex")
         self.geodiff.create_changeset_ex(
             'sqlite', '',
-            testdir()+'/base.gpkg',
-            testdir()+'/1_geopackage/modified_1_geom.gpkg',
+            geodiff_test_dir()+'/base.gpkg',
+            geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg',
             outdir+'/create-ex.diff')
 
         print("-- apply_changeset_ex")
         self.geodiff.make_copy_sqlite(
-            testdir()+'/base.gpkg',
+            geodiff_test_dir()+'/base.gpkg',
             outdir+'/apply-ex.gpkg')
         self.geodiff.apply_changeset_ex(
             'sqlite', '',
             outdir+'/apply-ex.gpkg',
-            testdir()+'/1_geopackage/base-modified_1_geom.diff')
+            geodiff_test_dir()+'/1_geopackage/base-modified_1_geom.diff')
 
         print("-- create_rebased_changeset_ex")
         self.geodiff.create_changeset_ex(
             'sqlite', '',
-            testdir()+'/base.gpkg',
-            testdir()+'/2_inserts/inserted_1_B.gpkg',
+            geodiff_test_dir()+'/base.gpkg',
+            geodiff_test_dir()+'/2_inserts/inserted_1_B.gpkg',
             outdir+'/rebased-ex-base2their.diff')
         self.geodiff.create_rebased_changeset_ex(
             'sqlite', '',
-            testdir()+'/base.gpkg',
-            testdir()+'/2_inserts/base-inserted_1_A.diff',
+            geodiff_test_dir()+'/base.gpkg',
+            geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff',
             outdir+'/rebased-ex-base2their.diff',
             outdir+'/rebased-ex.diff',
             outdir+'/rebased-ex-conflicts.json')
 
         print("-- rebase_ex")
         self.geodiff.make_copy_sqlite(
-            testdir()+'/2_inserts/inserted_1_B.gpkg',
+            geodiff_test_dir()+'/2_inserts/inserted_1_B.gpkg',
             outdir+'/rebase-ex.gpkg')
         self.geodiff.rebase_ex(
             'sqlite', '',
-            testdir()+'/base.gpkg',
+            geodiff_test_dir()+'/base.gpkg',
             outdir+'/rebase-ex.gpkg',
-            testdir()+'/2_inserts/base-inserted_1_A.diff',
+            geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff',
             outdir+'/rebase-ex-conflicts.json')
 
         print("-- dump_data")
         self.geodiff.dump_data(
             'sqlite', '',
-            testdir()+'/base.gpkg',
+            geodiff_test_dir()+'/base.gpkg',
             outdir+'/dump-data.diff')
 
         print("-- schema")
         self.geodiff.schema(
             'sqlite', '',
-            testdir()+'/base.gpkg',
+            geodiff_test_dir()+'/base.gpkg',
             outdir+'/schema.json')

--- a/pygeodiff/tests/test_changeset_reader.py
+++ b/pygeodiff/tests/test_changeset_reader.py
@@ -4,7 +4,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from .testutils import GeoDiffTests, testdir
+from .testutils import GeoDiffTests, geodiff_test_dir
 from pygeodiff import ChangesetEntry, ChangesetReader, GeoDiffLibError, UndefinedValue
 import os
 
@@ -12,19 +12,19 @@ import os
 class UnitTestsChangesetReader(GeoDiffTests):
 
     def test_invalid_file(self):
-        changeset = os.path.join(testdir(), "missing-file.diff")
+        changeset = os.path.join(geodiff_test_dir(), "missing-file.diff")
         with self.assertRaises(GeoDiffLibError):
             ch_reader = self.geodiff.read_changeset(changeset)
 
         # existing file, but wrong format... reader will be created fine
         # (there's no header to verify it's the right file type)
-        changeset = os.path.join(testdir(), "base.gpkg")
+        changeset = os.path.join(geodiff_test_dir(), "base.gpkg")
         ch_reader = self.geodiff.read_changeset(changeset)
         with self.assertRaises(GeoDiffLibError):
             ch_reader.next_entry()
 
     def test_basic(self):
-        changeset = os.path.join(testdir(), "1_geopackage", "base-modified_1_geom.diff")
+        changeset = os.path.join(geodiff_test_dir(), "1_geopackage", "base-modified_1_geom.diff")
         ch_reader = self.geodiff.read_changeset(changeset)
         self.assertIsInstance(ch_reader, ChangesetReader)
         entry = ch_reader.next_entry()
@@ -35,7 +35,7 @@ class UnitTestsChangesetReader(GeoDiffTests):
         self.assertEqual(entry, None)
 
     def test_iterator(self):
-        changeset = os.path.join(testdir(), "1_geopackage", "base-modified_1_geom.diff")
+        changeset = os.path.join(geodiff_test_dir(), "1_geopackage", "base-modified_1_geom.diff")
         i = 0
         for entry in self.geodiff.read_changeset(changeset):
             self.assertEqual(entry.operation, ChangesetEntry.OP_UPDATE)
@@ -55,7 +55,7 @@ class UnitTestsChangesetReader(GeoDiffTests):
         self.assertEqual(i, 2)
 
     def test_insert(self):
-        changeset = os.path.join(testdir(), "2_inserts", "base-inserted_1_A.diff")
+        changeset = os.path.join(geodiff_test_dir(), "2_inserts", "base-inserted_1_A.diff")
         i = 0
         for entry in self.geodiff.read_changeset(changeset):
             self.assertEqual(entry.table.name, 'simple')
@@ -67,7 +67,7 @@ class UnitTestsChangesetReader(GeoDiffTests):
         self.assertEqual(i, 1)
 
     def test_delete(self):
-        changeset = os.path.join(testdir(), "2_deletes", "base-deleted_A.diff")
+        changeset = os.path.join(geodiff_test_dir(), "2_deletes", "base-deleted_A.diff")
         i = 0
         for entry in self.geodiff.read_changeset(changeset):
             self.assertEqual(entry.table.name, 'simple')

--- a/pygeodiff/tests/test_cli.py
+++ b/pygeodiff/tests/test_cli.py
@@ -45,35 +45,49 @@ class UnitTestsCliCalls(GeoDiffCliTests):
         self.run_command(["diff", geodiff_test_dir()+'/non-existent.gpkg'], expect_fail=True )
         self.run_command(["diff", geodiff_test_dir()+'/non-existent.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True )
         self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
+        self.run_command(["diff", '--json', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True )
+        self.run_command(["diff", '--driver1', 'sqlite', '\'\'', '--driver2', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary", expect_fail=True )
+        
         self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'] )
         self.run_command(["diff", '--json', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="update" )
         self.run_command(["diff", '--json', '--skip-tables', 'simple', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff" ) #empty diff
         self.run_command(["diff", '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary" )
         self.run_command(["diff", '--driver', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary" )
-        self.run_command(["diff", '--driver1', 'sqlite', '\'\'', '--driver2', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary", expect_fail=True )
         self.run_command(["diff", '--driver-1', 'sqlite', '\'\'', '--driver-2', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary" )
-        self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg', outdir + "/diff.diff"] )
+        self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/2_inserts/inserted_1_A.gpkg', outdir + "/diff.diff"] )
 
         print("-- copy" )
         self.run_command(["copy"], expect_fail=True )
         self.run_command(["copy", geodiff_test_dir()+'/non-existent.gpkg', outdir+'/copy.gpkg'], expect_fail=True )
         self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg', 'extra_arg'], expect_fail=True )
         self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg'])
+
         
         print("-- apply" )
+        self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copyA.gpkg'])
+        
         self.run_command(["apply"], expect_fail=True )
-        self.run_command(["apply", outdir+'/copy.gpkg'], expect_fail=True )
-        self.run_command(["apply", outdir+'/copy.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True ) # second arg is diff
-        self.run_command(["apply", outdir+'/copy.gpkg', outdir + "/diff.diff"] )
-        self.run_command(["apply", outdir+'/copy.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
+        self.run_command(["apply", outdir+'/copyA.gpkg'], expect_fail=True )
+        self.run_command(["apply", outdir+'/copyA.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True ) # second arg is diff
+        self.run_command(["apply", outdir+'/copyA.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
+        self.run_command(["apply", outdir+'/copyA.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'] )
         
         print("-- rebase-diff" )
-        # DB_BASE CH_BASE_OUR CH_BASE_THEIR CH_REBASED CONFLICT
-        # TODO 
+        self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copyF.gpkg'])
+        
+        self.run_command(["rebase-diff"], expect_fail=True )
+        self.run_command(["rebase-diff", outdir+'/copyF.gpkg'], expect_fail=True )
+        self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True ) # second arg is diff
+        self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff', geodiff_test_dir()+'/2_updates/base-updated_A.diff', outdir + "/rebase-diff.diff" , outdir + "/confF.confict" , 'extra_arg'], expect_fail=True )
+        self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff', geodiff_test_dir()+'/2_updates/base-updated_A.diff', outdir + "/rebase-diff.diff" , outdir + "/confF.confict"] )
         
         print("-- rebase-db" )
-        # TODO
-
+        self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copyD.gpkg'])
+        
+        self.run_command(["rebase-db"], expect_fail=True )
+        self.run_command(["rebase-db", geodiff_test_dir()+'/base.gpkg', outdir+'/copyD.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'], expect_fail=True) # missing arg
+        self.run_command(["rebase-db", geodiff_test_dir()+'/base.gpkg', outdir+'/copyD.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff',outdir + "/rebasedb.conflicts.json"])
+        
         print("-- invert" )
         self.run_command(["invert"], expect_fail=True )
         self.run_command(["invert", geodiff_test_dir()+'/concat/bar-insert.diff'], expect_fail=True)

--- a/pygeodiff/tests/test_cli.py
+++ b/pygeodiff/tests/test_cli.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: (c) 2023 Peter Petrik
+    :license: MIT, see LICENSE for more details.
+"""
+
+from .testutils import *
+import os
+import shutil
+
+class UnitTestsCliCalls(GeoDiffCliTests):
+    """ Some quick tests of various CLI commands just to make sure they are not broken """
+
+    def test_cli_calls(self):
+        print("********************************************************")
+        print("PYTHON: test API calls")
+
+        outdir = create_dir("cli-calls")
+
+        print("-- invalid")
+        self.run_command([], expect_fail=True )
+        
+        print("-- dump" )
+        self.run_command(["dump"], expect_fail=True )
+        self.run_command(["dump", geodiff_test_dir()+'/base.gpkg'], expect_fail=True )
+        self.run_command(["dump", geodiff_test_dir()+'/base.gpkg', outdir + "/dump2.diff", "extra_arg" ], expect_fail=True )
+        self.run_command(["dump", geodiff_test_dir()+'/base.gpkg', outdir + "/dump.diff"] )
+        
+        print("-- as-json" )
+        self.run_command(["as-json"], expect_fail=True )
+        self.run_command(["as-json", "arg1", "extra_arg"], expect_fail=True )
+        self.run_command(["as-json", outdir + "/dump.diff"], check_in_output="feature2" )
+        self.run_command(["as-json", outdir + "/dump.diff", outdir + "/dump.json"] )
+        file_contains( outdir + "/dump.json", "feature3")
+        
+        print("-- as-summary" )
+        self.run_command(["as-summary"], expect_fail=True )
+        self.run_command(["as-summary", "arg1", "extra_arg"], expect_fail=True )
+        self.run_command(["as-summary", outdir + "/dump.diff"], check_in_output="geodiff_summary" )
+        self.run_command(["as-summary", outdir + "/dump.diff", outdir + "/dump.json"] )
+        file_contains( outdir + "/dump.json", "geodiff_summary")
+
+        print("-- diff" )
+        self.run_command(["diff"], expect_fail=True )
+        self.run_command(["diff", geodiff_test_dir()+'/non-existent.gpkg'], expect_fail=True )
+        self.run_command(["diff", geodiff_test_dir()+'/non-existent.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True )
+        self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
+        self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'] )
+        self.run_command(["diff", '--json', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="update" )
+        self.run_command(["diff", '--json', '--skip-tables', 'simple', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff" ) #empty diff
+        self.run_command(["diff", '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary" )
+        self.run_command(["diff", '--driver', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary" )
+        self.run_command(["diff", '--driver1', 'sqlite', '\'\'', '--driver2', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary", expect_fail=True )
+        self.run_command(["diff", '--driver-1', 'sqlite', '\'\'', '--driver-2', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary" )
+        self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg', outdir + "/diff.diff"] )
+
+        print("-- copy" )
+        self.run_command(["copy"], expect_fail=True )
+        self.run_command(["copy", geodiff_test_dir()+'/non-existent.gpkg', outdir+'/copy.gpkg'], expect_fail=True )
+        self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg', 'extra_arg'], expect_fail=True )
+        self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg'])
+        
+        print("-- apply" )
+        self.run_command(["apply"], expect_fail=True )
+        self.run_command(["apply", outdir+'/copy.gpkg'], expect_fail=True )
+        self.run_command(["apply", outdir+'/copy.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True ) # second arg is diff
+        self.run_command(["apply", outdir+'/copy.gpkg', outdir + "/diff.diff"] )
+        self.run_command(["apply", outdir+'/copy.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
+        
+        print("-- rebase-diff" )
+        # DB_BASE CH_BASE_OUR CH_BASE_THEIR CH_REBASED CONFLICT
+        # TODO 
+        
+        print("-- rebase-db" )
+        # TODO
+
+        print("-- invert" )
+        self.run_command(["invert"], expect_fail=True )
+        self.run_command(["invert", geodiff_test_dir()+'/concat/bar-insert.diff'], expect_fail=True)
+        self.run_command(["invert", geodiff_test_dir()+'/concat/bar-insert.diff', outdir+'/invert.diff'])
+        self.run_command(["invert", geodiff_test_dir()+'/concat/non-existent-file.diff', outdir+'/invert.diff'], expect_fail=True)
+        self.run_command(["as-json", outdir+'/invert.diff'], check_in_output="points" )
+        
+        print("-- concat" )
+        self.run_command(["concat"], expect_fail=True )
+        self.run_command(["concat", geodiff_test_dir()+'/concat/non-existent-file.diff', geodiff_test_dir()+'/concat/bar-update.diff', outdir+'/concat-fail.diff'], expect_fail=True)
+        self.run_command(["concat", geodiff_test_dir()+'/concat/bar-insert.diff', geodiff_test_dir()+'/concat/bar-update.diff', outdir+'/concat2.diff'])
+        self.run_command(["as-json", outdir+'/concat2.diff'], check_in_output="MODIFIED" )
+        self.run_command(["concat", geodiff_test_dir()+'/concat/bar-insert.diff', geodiff_test_dir()+'/concat/bar-update.diff', geodiff_test_dir()+'/concat/bar-delete.diff', outdir+'/concat3.diff'])
+        self.run_command(["as-json", outdir+'/concat3.diff'], check_in_output="geodiff" ) # empty file
+        
+        print("-- schema" )
+        self.run_command(["schema"], expect_fail=True )
+        self.run_command(["schema", geodiff_test_dir()+'/non-existent.gpkg'], expect_fail=True )
+        self.run_command(["schema", geodiff_test_dir()+'/base.gpkg'], check_in_output="MEDIUMINT" )
+        self.run_command(["schema", geodiff_test_dir()+'/base.gpkg', outdir+'/schema.txt'])
+        file_contains( outdir + "/schema.txt", "MEDIUMINT")
+        self.run_command(["schema", geodiff_test_dir()+'/base.gpkg', outdir+'/schema-fail.txt', "extra_arg"], expect_fail=True )
+        
+        print("-- drivers") 
+        self.run_command(["drivers"], check_in_output="sqlite" )
+        self.run_command(["drivers", "extra_arg"], expect_fail=True )
+        
+        print("-- version") 
+        self.run_command(["version"], check_in_output="." )
+        self.run_command(["version", "extra_arg"], expect_fail=True )
+        
+        print("-- help")
+        self.run_command(["help"], check_in_output="Lutra Consulting")
+        self.run_command(["help", "extra_arg"], expect_fail=True )

--- a/pygeodiff/tests/test_cli.py
+++ b/pygeodiff/tests/test_cli.py
@@ -19,6 +19,7 @@ class UnitTestsCliCalls(GeoDiffCliTests):
 
         print("-- invalid")
         self.run_command([], expect_fail=True )
+        self.run_command(["badcommand"], expect_fail=True )
         
         print("-- dump" )
         self.run_command(["dump"], expect_fail=True )
@@ -76,6 +77,8 @@ class UnitTestsCliCalls(GeoDiffCliTests):
         self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copyB.gpkg'])
         
         self.run_command(["apply"], expect_fail=True )
+        self.run_command(["apply", '--driver'], expect_fail=True )
+        self.run_command(["apply", '--skip-tables'], expect_fail=True )
         self.run_command(["apply", outdir+'/copyA.gpkg'], expect_fail=True )
         self.run_command(["apply", outdir+'/copyA.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True ) # second arg is diff
         self.run_command(["apply", outdir+'/copyA.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )

--- a/pygeodiff/tests/test_cli.py
+++ b/pygeodiff/tests/test_cli.py
@@ -47,7 +47,9 @@ class UnitTestsCliCalls(GeoDiffCliTests):
         self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
         self.run_command(["diff", '--json', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True )
         self.run_command(["diff", '--driver1', 'sqlite', '\'\'', '--driver2', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary", expect_fail=True )
-        
+        self.run_command(["diff", '--driver1', 'sqlite', '--driver2', 'sqlite', '\'\'', '--summary', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff_summary", expect_fail=True )
+        self.run_command(["diff", '--json', '--skip-tables', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff", expect_fail=True )
+                
         self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'] )
         self.run_command(["diff", '--json', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="update" )
         self.run_command(["diff", '--json', '--skip-tables', 'simple', geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], check_in_output="geodiff" ) #empty diff
@@ -60,17 +62,29 @@ class UnitTestsCliCalls(GeoDiffCliTests):
         self.run_command(["copy"], expect_fail=True )
         self.run_command(["copy", geodiff_test_dir()+'/non-existent.gpkg', outdir+'/copy.gpkg'], expect_fail=True )
         self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg', 'extra_arg'], expect_fail=True )
+        self.run_command(["copy", '--skip-tables', geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg'], expect_fail=True )
+        self.run_command(["copy", '--driver-1', geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg'], expect_fail=True )
+        self.run_command(["copy", '--driver-2', geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg'], expect_fail=True )
+        self.run_command(["copy", '--driver', 'sqlite', '\'\'',  '--skip-tables', 'unknown', geodiff_test_dir()+'/base.gpkg', outdir+'/copy2.gpkg'], expect_fail=True)
+        
         self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copy.gpkg'])
-
         
         print("-- apply" )
         self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copyA.gpkg'])
+        self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copyB.gpkg'])
         
         self.run_command(["apply"], expect_fail=True )
         self.run_command(["apply", outdir+'/copyA.gpkg'], expect_fail=True )
         self.run_command(["apply", outdir+'/copyA.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True ) # second arg is diff
         self.run_command(["apply", outdir+'/copyA.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
-        self.run_command(["apply", outdir+'/copyA.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'] )
+        self.run_command(["apply", outdir+'/copyA.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
+        self.run_command(["apply", '--driver', outdir+'/copyA.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'], expect_fail=True )
+        self.run_command(["apply", '--driver', 'sqlite', outdir+'/copyA.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'], expect_fail=True )
+        self.run_command(["apply", '--skip-tables', outdir+'/copyA.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'], expect_fail=True )
+        self.run_command(["apply", '--invalid-flag', outdir+'/copyA.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'], expect_fail=True )
+        
+        self.run_command(["apply", '--driver', 'sqlite', '\'\'', '--skip-tables', '\'\'', outdir+'/copyA.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'] )
+        self.run_command(["apply", outdir+'/copyB.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'] )
         
         print("-- rebase-diff" )
         self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copyF.gpkg'])

--- a/pygeodiff/tests/test_cli.py
+++ b/pygeodiff/tests/test_cli.py
@@ -42,6 +42,8 @@ class UnitTestsCliCalls(GeoDiffCliTests):
 
         print("-- diff" )
         self.run_command(["diff"], expect_fail=True )
+        self.run_command(["diff", '--driver1'], expect_fail=True )
+        self.run_command(["diff", '--skip-tables'], expect_fail=True )
         self.run_command(["diff", geodiff_test_dir()+'/non-existent.gpkg'], expect_fail=True )
         self.run_command(["diff", geodiff_test_dir()+'/non-existent.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True )
         self.run_command(["diff", geodiff_test_dir()+'/base.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg', outdir + "/diff.diff", 'extra_arg'], expect_fail=True )
@@ -93,20 +95,32 @@ class UnitTestsCliCalls(GeoDiffCliTests):
         self.run_command(["rebase-diff", outdir+'/copyF.gpkg'], expect_fail=True )
         self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/1_geopackage/modified_1_geom.gpkg'], expect_fail=True ) # second arg is diff
         self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff', geodiff_test_dir()+'/2_updates/base-updated_A.diff', outdir + "/rebase-diff.diff" , outdir + "/confF.confict" , 'extra_arg'], expect_fail=True )
+        self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff', geodiff_test_dir()+'/bad.diff', outdir + "/rebase-diff.diff" , outdir + "/confF.confict"], expect_fail=True )
+        self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/bad.diff', geodiff_test_dir()+'/2_updates/base-updated_A.diff', outdir + "/rebase-diff.diff" , outdir + "/confF.confict"], expect_fail=True )
+        self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff', geodiff_test_dir()+'/2_updates/base-updated_A.diff', outdir + "/rebase-diff.diff"], expect_fail=True )
+
         self.run_command(["rebase-diff", outdir+'/copyF.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff', geodiff_test_dir()+'/2_updates/base-updated_A.diff', outdir + "/rebase-diff.diff" , outdir + "/confF.confict"] )
         
         print("-- rebase-db" )
         self.run_command(["copy", geodiff_test_dir()+'/base.gpkg', outdir+'/copyD.gpkg'])
         
         self.run_command(["rebase-db"], expect_fail=True )
+        self.run_command(["rebase-db", "--bad_flag"], expect_fail=True )
         self.run_command(["rebase-db", geodiff_test_dir()+'/base.gpkg', outdir+'/copyD.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff'], expect_fail=True) # missing arg
+        self.run_command(["rebase-db", geodiff_test_dir()+'/bad.gpkg', outdir+'/copyD.gpkg', geodiff_test_dir()+'/bad.diff',outdir + "/rebasedb.conflicts.json"], expect_fail=True)
+        self.run_command(["rebase-db", geodiff_test_dir()+'/base.gpkg', outdir+'/copyD.gpkg', geodiff_test_dir()+'/bad.diff',outdir + "/rebasedb.conflicts.json"], expect_fail=True)
+        self.run_command(["rebase-db", geodiff_test_dir()+'/base.gpkg', outdir+'/bad.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff',outdir + "/rebasedb.conflicts.json"], expect_fail=True)
+        
         self.run_command(["rebase-db", geodiff_test_dir()+'/base.gpkg', outdir+'/copyD.gpkg', geodiff_test_dir()+'/2_inserts/base-inserted_1_A.diff',outdir + "/rebasedb.conflicts.json"])
         
         print("-- invert" )
         self.run_command(["invert"], expect_fail=True )
+        self.run_command(["invert", "--bad_flag"], expect_fail=True )
         self.run_command(["invert", geodiff_test_dir()+'/concat/bar-insert.diff'], expect_fail=True)
-        self.run_command(["invert", geodiff_test_dir()+'/concat/bar-insert.diff', outdir+'/invert.diff'])
+        self.run_command(["invert", geodiff_test_dir()+'/concat/bar-insert.diff', outdir+'/invert.diff', 'extra_arg'], expect_fail=True)
         self.run_command(["invert", geodiff_test_dir()+'/concat/non-existent-file.diff', outdir+'/invert.diff'], expect_fail=True)
+        
+        self.run_command(["invert", geodiff_test_dir()+'/concat/bar-insert.diff', outdir+'/invert.diff'])
         self.run_command(["as-json", outdir+'/invert.diff'], check_in_output="points" )
         
         print("-- concat" )

--- a/pygeodiff/tests/test_concurrent_commits.py
+++ b/pygeodiff/tests/test_concurrent_commits.py
@@ -15,9 +15,9 @@ class UnitTestsPythonConcurrentCommits(GeoDiffTests):
         testname = "2_inserts"
         create_dir(testname)
 
-        base = testdir() + "/base.gpkg"
-        modifiedA = testdir() + "/" + testname + "/" + "inserted_1_A.gpkg"
-        modifiedB = testdir() + "/" + testname + "/" + "inserted_1_B.gpkg"
+        base = geodiff_test_dir() + "/base.gpkg"
+        modifiedA = geodiff_test_dir() + "/" + testname + "/" + "inserted_1_A.gpkg"
+        modifiedB = geodiff_test_dir() + "/" + testname + "/" + "inserted_1_B.gpkg"
         changesetbaseA = tmpdir() + "/py" + testname + "/" + "changeset_base_to_A.bin"
         changesetAB = tmpdir() + "/py" + testname + "/" + "changeset_A_to_B.bin"
         conflictAB = tmpdir() + "/py" + testname + "/" + "conflict_A_to_B.json"

--- a/pygeodiff/tests/test_errors.py
+++ b/pygeodiff/tests/test_errors.py
@@ -13,8 +13,8 @@ class UnitTestsPythonErrors(GeoDiffTests):
     def test_unsupported_change_error(self):
         create_dir("unsupported_change")
 
-        base = testdir() + "/base.gpkg"
-        modified = testdir() + "/modified_scheme/added_attribute.gpkg"
+        base = geodiff_test_dir() + "/base.gpkg"
+        modified = geodiff_test_dir() + "/modified_scheme/added_attribute.gpkg"
         changeset = tmpdir() + "/pyunsupported_change/changeset.bin"
 
         try:
@@ -25,9 +25,9 @@ class UnitTestsPythonErrors(GeoDiffTests):
 
     def test_conflict_error(self):
         create_dir("conflict_error")
-        base = testdir() + "/base.gpkg"
-        modifiedA = testdir() + "/2_updates/updated_A.gpkg"
-        modifiedB = testdir() + "/2_updates/updated_B.gpkg"
+        base = geodiff_test_dir() + "/base.gpkg"
+        modifiedA = geodiff_test_dir() + "/2_updates/updated_A.gpkg"
+        modifiedB = geodiff_test_dir() + "/2_updates/updated_B.gpkg"
         base2 = tmpdir() + "/pyconflict_error/base2.gpkg"
         changesetbaseA = tmpdir() + "/pyconflict_error/changesetbaseA.bin"
         shutil.copyfile(modifiedB, base2)
@@ -41,10 +41,10 @@ class UnitTestsPythonErrors(GeoDiffTests):
 
     def test_not_implemented(self):
         create_dir("not_implemented")
-        base = testdir() + "/base_fk.gpkg"
+        base = geodiff_test_dir() + "/base_fk.gpkg"
 
-        modifiedA = testdir() + "/fk_2_updates/modified_fk_A.gpkg"
-        modifiedB = testdir() + "/fk_2_updates/modified_fk_B.gpkg"
+        modifiedA = geodiff_test_dir() + "/fk_2_updates/modified_fk_A.gpkg"
+        modifiedB = geodiff_test_dir() + "/fk_2_updates/modified_fk_B.gpkg"
 
         base2 = tmpdir() + "/pynot_implemented/base2.gpkg"
         changesetbaseA = tmpdir() + "/pynot_implemented/changesetbaseA.bin"

--- a/pygeodiff/tests/test_geometry_utils.py
+++ b/pygeodiff/tests/test_geometry_utils.py
@@ -4,7 +4,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from .testutils import GeoDiffTests, testdir
+from .testutils import GeoDiffTests, geodiff_test_dir
 from pygeodiff import ChangesetEntry, ChangesetReader, GeoDiffLibError, UndefinedValue
 import os
 

--- a/pygeodiff/tests/test_single_commit.py
+++ b/pygeodiff/tests/test_single_commit.py
@@ -21,8 +21,8 @@ def basetest(
   print( "PYTHON: " + testname )
   create_dir(testname)
 
-  base = testdir() + "/" + basename
-  modified = testdir() + "/" + testname + "/" + modifiedname
+  base = geodiff_test_dir() + "/" + basename
+  modified = geodiff_test_dir() + "/" + testname + "/" + modifiedname
   changeset = tmpdir() + "/py" + testname + "/" + "changeset_" + basename + ".bin"
   changeset2 = tmpdir() + "/py" + testname + "/" + "changeset_after_apply_" + basename + ".bin"
   changeset_inv = tmpdir() + "/py" + testname + "/" + "changeset_inv" + basename + ".bin"
@@ -80,4 +80,4 @@ class UnitTestsPythonSingleCommit(GeoDiffTests):
              "complex1.gpkg",
              6,
              True,
-             expected_json=testdir() + "/complex/complex1.json")
+             expected_json=geodiff_test_dir() + "/complex/complex1.json")

--- a/pygeodiff/tests/test_skip_tables.py
+++ b/pygeodiff/tests/test_skip_tables.py
@@ -11,9 +11,9 @@ import pygeodiff
 
 class UnitTestsPythonSingleCommit(GeoDiffTests):
     def test_skip_create(self):
-        base = testdir() + "/" + "skip_tables" + "/" + "base.gpkg"
-        modified = testdir() + "/" + "skip_tables" + "/" + "modified_all.gpkg"
-        modified_points = testdir() + "/" + "skip_tables" + "/" + "modified_points.gpkg"
+        base = geodiff_test_dir() + "/" + "skip_tables" + "/" + "base.gpkg"
+        modified = geodiff_test_dir() + "/" + "skip_tables" + "/" + "modified_all.gpkg"
+        modified_points = geodiff_test_dir() + "/" + "skip_tables" + "/" + "modified_points.gpkg"
         changeset = tmpdir() + "/py" + "test_skip_create" + "/" + "changeset_points.bin"
         changeset2 = tmpdir() + "/py" + "test_skip_create" + "/" + "changeset_points2.bin"
         changeset_inv = tmpdir() + "/py" + "test_skip_create" + "/" + "changeset_inv.bin"
@@ -46,9 +46,9 @@ class UnitTestsPythonSingleCommit(GeoDiffTests):
         self.geodiff.set_tables_to_skip([])
 
     def test_skip_apply(self):
-        base = testdir() + "/" + "skip_tables" + "/" + "base.gpkg"
-        modified = testdir() + "/" + "skip_tables" + "/" + "modified_all.gpkg"
-        modified_points = testdir() + "/" + "skip_tables" + "/" + "modified_points.gpkg"
+        base = geodiff_test_dir() + "/" + "skip_tables" + "/" + "base.gpkg"
+        modified = geodiff_test_dir() + "/" + "skip_tables" + "/" + "modified_all.gpkg"
+        modified_points = geodiff_test_dir() + "/" + "skip_tables" + "/" + "modified_points.gpkg"
         changeset = tmpdir() + "/py" + "test_skip_apply" + "/" + "changeset_points.bin"
         changeset2 = tmpdir() + "/py" + "test_skip_apply" + "/" + "changeset_points2.bin"
         changeset_inv = tmpdir() + "/py" + "test_skip_apply" + "/" + "changeset_inv.bin"


### PR DESCRIPTION
fix #183 cli-auto-tests
also replaced `testdir()`, since `pytest3.10` tried to execute this helper function as regular test.

![Screenshot 2023-01-18 at 15 06 57](https://user-images.githubusercontent.com/804608/213192359-e70f65e2-c59b-497c-b78f-41a0d5e598ae.png)
